### PR TITLE
Simplify with or

### DIFF
--- a/ui2/delay.py
+++ b/ui2/delay.py
@@ -44,7 +44,7 @@ class Delay(object):
     def __init__(self, func, seconds, id=None, manager=delay_manager):
         self.function = func
         self.seconds = seconds
-        self.id = str(uuid.uuid4()) if id is None else id
+        self.id = id or str(uuid.uuid4())
         self.manager = manager
 
         def func():


### PR DESCRIPTION
Also, Delay **has** a Timer... 

Would the code be simpler if Delay **was** a Timer?  E.g. `class Delay(threading.Timer):`
